### PR TITLE
Clarify that this repo is stale

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # barista3
 
-This is a fork of https://github.com/dart-lang/flute which has since become stale. For benchmarking or just as an example of a Flutter application compiled to WebAssembly, please see the upstream repository. Thanks!
+This is a fork of https://github.com/dart-lang/flute which has since become stale. For benchmarking of a Flutter application compiled to WebAssembly, please see the upstream repository. Thanks!

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# flute
+# barista3
 
-A stipped down Flutter that has all the framework functionality but doesn't render anything. Good for benchmarking various Dart build modes (AOT vs dart2js vs JIT vs debug vs profile vs release...) on various hardware profiles (browser vs desktop vs mobile) such that performance is only affected by the language runtime and not by graphics or any other external systems.
+This is a fork of https://github.com/dart-lang/flute which has since become stale. For benchmarking or just as an example of a Flutter application compiled to WebAssembly, please see the upstream repository. Thanks!

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # barista3
 
-This is a fork of https://github.com/dart-lang/flute which has since become stale. For benchmarking of a Flutter application compiled to WebAssembly, please see the upstream repository. Thanks!
+This is a fork of https://github.com/dart-lang/flute which was modified to work with a very early version of the Dart-to-WebAssembly compiler. For the full, up-to-date version of Flute (stand-alone benchmark of Flutter framework code), please see the upstream repository. Thanks!


### PR DESCRIPTION
Hi @askeksa-google!

I have spoken to WebAssembly and dart2wasm folks and wanted to ask if you could archive this repo + modify the README such that it points to the upstream flute application.

My understanding is that this fork includes patches to the example application, such that it works with a relatively early version of the dart2wasm toolchain, but those are no longer necessary. Archiving this repo avoids confusion which of the applications is "more up to date" and the README change in this PR makes also explicitly directs people to the actively maintained upstream version.

WDYT?
Thanks,
Daniel